### PR TITLE
App Install Location

### DIFF
--- a/myTTR/src/main/AndroidManifest.xml
+++ b/myTTR/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.jmelzer.myttr">
+          package="com.jmelzer.myttr"
+          android:installLocation="auto">
 
     <uses-sdk
         android:maxSdkVersion="22"


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

"To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto"." (source: https://developer.android.com/guide/topics/data/install-location.html)

Thank you very much for your awesome app :)